### PR TITLE
add support for web proxy in Helm jobs

### DIFF
--- a/templates/jobs/pre-delete.yaml
+++ b/templates/jobs/pre-delete.yaml
@@ -45,5 +45,9 @@ spec:
             mountPath: /sql/stop.sh
             subPath: stop.sh
           command: ["/bin/sh", "-c"]
+          {{- if .Values.webProxy.enabled }}
+          args: ["http_proxy={{ .Values.webProxy.http }} https_proxy={{ .Values.webProxy.https }} no_proxy=localhost,127.0.0.1,docservice /sql/stop.sh"]
+          {{ else }}
           args: ["/sql/stop.sh"]
+          {{- end }}          
       restartPolicy: Never

--- a/templates/jobs/pre-rollback.yaml
+++ b/templates/jobs/pre-rollback.yaml
@@ -45,5 +45,9 @@ spec:
             mountPath: /sql/stop.sh
             subPath: stop.sh
           command: ["/bin/sh", "-c"]
+          {{- if .Values.webProxy.enabled }}
+          args: ["http_proxy={{ .Values.webProxy.http }} https_proxy={{ .Values.webProxy.https }} no_proxy=localhost,127.0.0.1,docservice /sql/stop.sh"]
+          {{ else }}
           args: ["/sql/stop.sh"]
+          {{- end }}
       restartPolicy: Never

--- a/templates/jobs/prepare-ds.yaml
+++ b/templates/jobs/prepare-ds.yaml
@@ -45,5 +45,9 @@ spec:
             mountPath: /sql/stop.sh
             subPath: stop.sh
           command: ["/bin/sh", "-c"]
+          {{- if .Values.webProxy.enabled }}
+          args: ["http_proxy={{ .Values.webProxy.http }} https_proxy={{ .Values.webProxy.https }} no_proxy=localhost,127.0.0.1,docservice /sql/stop.sh"]
+          {{ else }}
           args: ["/sql/stop.sh"]
+          {{- end }}          
       restartPolicy: Never

--- a/values.yaml
+++ b/values.yaml
@@ -1,6 +1,11 @@
 product:
   name: onlyoffice
 
+webProxy:
+  enabled: false
+  http: "http://proxy.example.com"
+  https: "https://proxy.example.com"  
+
 connections:
   dbHost: postgresql
   dbUser: postgres


### PR DESCRIPTION
Hi,

Helm jobs use a script (stop-ds.yaml) that needs internet access. Problem : in my case, we are using a web proxy so `helm upgrade`, `helm uninstall` and `helm rollback` will not work (in short, all helm command that use this script)
i made a request on onlyoffice helpdesk (n°33389) and here is my proposal to solve this problem.

Hope it helps :)
Regards.
Yoann.
